### PR TITLE
fix(marketing): ui padding for blog-card showcase page to follow design layout

### DIFF
--- a/apps/marketing/src/pages/showcases/blog-card.tsx
+++ b/apps/marketing/src/pages/showcases/blog-card.tsx
@@ -13,7 +13,7 @@ export const BlogCardShowCase = (cardData?: Partial<BlogCardProps>) => {
   const mergedCardData = { ...defaultCardData, ...cardData };
   return (
     <section className={"flex flex-col items-center bg-gray-200"}>
-      <main className="mx-auto items-center overflow-x-auto py-[200px] align-top">
+      <main className="mx-auto items-center overflow-x-auto pt-[120px] align-top">
         <BlogCard {...mergedCardData} />
       </main>
     </section>


### PR DESCRIPTION
### Issue / Bugs / Errors

From submission vs design we see that the submission has the blog-card positioned way too low compared to the original design.

<img width="1204" height="706" alt="Screenshot 2025-09-10 at 9 29 25 PM" src="https://github.com/user-attachments/assets/a3deca89-9cdd-4f10-a535-fb7bb1c34b27" />

### Resolution / Fix

The solution is to update the padding to follow Figma design: 
- before: padding y 200px
- after: padding top 100px