### PR TITLE
ci(railway): include and fix watchPatterns for apps/marketing

### DIFF
--- a/apps/marketing/railway.json
+++ b/apps/marketing/railway.json
@@ -2,7 +2,8 @@
   "$schema": "https://railway.com/railway.schema.json",
   "build": {
     "builder": "DOCKERFILE",
-    "dockerfilePath": "apps/marketing/Dockerfile"
+    "dockerfilePath": "apps/marketing/Dockerfile",
+    "watchPatterns": ["/apps/marketing", "/packages/", "!/*.md"]
   },
   "deploy": {
     "numReplicas": 1,


### PR DESCRIPTION

### Issue / Bugs / Problem 

Currently, the watchPattern path is set via Railway console.

<img width="657" height="339" alt="Screenshot 2025-09-10 at 9 46 47 PM" src="https://github.com/user-attachments/assets/3bf86302-0502-4fd3-af99-5fce1c0c996d" />

However, for some reason the last PR merge into main branch did not qualify as changed path according to the watch pattern. It was skipped from deployment when merging to main.
```
No changed files matched patterns: /apps/marketing/**, /packages/ui/**
```
<img width="879" height="462" alt="image" src="https://github.com/user-attachments/assets/90d8d58c-0d1d-4765-a1af-2122cdbc886e" />

From documentation: https://docs.railway.com/guides/build-configuration#configure-watch-paths

Seems like we can and safer to use apps/marketing (without `**` wildcards) because `./**` may be interpreted as just the one-level files in that directory but not the recursive file in it.