### PR TITLE
fix(marketing): fix layout where html does not take full height available in device and fix overflow settings in showcases page to scroll

### DIFF
--- a/apps/marketing/src/index.css
+++ b/apps/marketing/src/index.css
@@ -1,7 +1,17 @@
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,100..900;1,100..900&display=swap");
 @import "tailwindcss";
 
 @theme {
   --default-font-family: "Noto Sans", var(--font-sans);
 }
 
+@layer base {
+  html,
+  body,
+  #root {
+    margin: 0;
+    padding: 0;
+    height: 100vh;
+    overflow: hidden;
+  }
+}

--- a/apps/marketing/src/pages/showcases/blog-card.tsx
+++ b/apps/marketing/src/pages/showcases/blog-card.tsx
@@ -12,7 +12,7 @@ const defaultCardData = {
 export const BlogCardShowCase = (cardData?: Partial<BlogCardProps>) => {
   const mergedCardData = { ...defaultCardData, ...cardData };
   return (
-    <section className={"flex flex-col items-center bg-gray-200"}>
+    <section className="flex h-full flex-col items-center bg-gray-200">
       <main className="mx-auto items-center overflow-x-auto pt-[120px] align-top">
         <BlogCard {...mergedCardData} />
       </main>

--- a/apps/marketing/src/pages/showcases/navbar.tsx
+++ b/apps/marketing/src/pages/showcases/navbar.tsx
@@ -2,7 +2,7 @@ import { Navbar } from "~/components/layout/navbar";
 
 export const NavbarShowcase = () => {
   return (
-    <main className="bg-linear-to-br h-screen from-gray-50 to-gray-400 to-90%">
+    <main className="bg-linear-to-br h-full from-gray-50 to-gray-400 to-90%">
       <Navbar />
     </main>
   );

--- a/apps/marketing/src/pages/showcases/profile-card.tsx
+++ b/apps/marketing/src/pages/showcases/profile-card.tsx
@@ -12,7 +12,7 @@ const defaultCardData: ProfileCardProps = {
 
 export const ProfileCardShowcase = () => {
   return (
-    <section className="flex flex-col items-center bg-gray-200">
+    <section className="flex h-full flex-col items-center bg-gray-200">
       <div className="mx-auto items-center overflow-x-auto py-[200px] align-top">
         <ProfileCard {...defaultCardData} />
       </div>

--- a/apps/marketing/src/pages/showcases/testimonial-card.tsx
+++ b/apps/marketing/src/pages/showcases/testimonial-card.tsx
@@ -12,7 +12,7 @@ const defaultCardData: TestimonialCardProps = {
 export const TestimonialCardShowcase = (cardData: Partial<TestimonialCardProps>) => {
   const mergedCardData = { ...defaultCardData, ...cardData };
   return (
-    <section className={"h-screen w-screen bg-gray-200"}>
+    <section className={"h-full w-screen bg-gray-200"}>
       <div className="mx-auto w-[340px] items-center overflow-x-auto py-[200px] align-top">
         <TestimonialCard {...mergedCardData} />
       </div>

--- a/apps/marketing/src/pages/showcases/testimonial-section.tsx
+++ b/apps/marketing/src/pages/showcases/testimonial-section.tsx
@@ -81,7 +81,7 @@ const testimonials: TestimonialSectionsProps["testimonials"] = [
 
 export const TestimonialSectionsShowcase = () => {
   return (
-    <section className={"flex flex-col items-center bg-white"}>
+    <section className={"flex h-full flex-col items-center bg-white"}>
       <div className="mx-auto items-center overflow-x-auto p-24 align-top">
         <TestimonialSections testimonials={testimonials} />
       </div>


### PR DESCRIPTION
### Issue / Problems

As seen from the console, the website html does not take the full height of the browser. The remaining white space below are void space, not part of any of the HTML.

<img width="1247" height="824" alt="Screenshot 2025-09-10 at 10 10 54 PM" src="https://github.com/user-attachments/assets/ff608936-c60c-4baf-983c-9730cad397d9" />


### Resolution / Fix

Need to setup base CSS in the root / global css file.
```
html,
  body,
  #root {
    margin: 0;
    padding: 0;
    height: 100vh;
    overflow: hidden;
  }
```