### PR TITLE
fix(marketing): fix layout, spacing, text-center and font-weight to fix UI for testimonial-section showcase page

### DIFF
--- a/apps/marketing/src/components/ui/testimonial-card.tsx
+++ b/apps/marketing/src/components/ui/testimonial-card.tsx
@@ -22,12 +22,12 @@ export const TestimonialCard = ({
         <div className="flex-auto">
           <div className="flex flex-col items-start justify-between">
             <span className="text-left text-lg font-semibold">{fullname}</span>
-            <span className="text-left text-sm font-normal text-neutral-600">{"@" + username}</span>
+            <span className="text-left text-sm font-light text-neutral-500">{"@" + username}</span>
           </div>
         </div>
       </div>
       <div className="w-full">
-        <p className="text-base font-normal text-neutral-600">{content}</p>
+        <p className="text-base font-light text-neutral-500">{content}</p>
       </div>
     </div>
   );

--- a/apps/marketing/src/pages/landing/sections/testimonial-section.tsx
+++ b/apps/marketing/src/pages/landing/sections/testimonial-section.tsx
@@ -7,9 +7,9 @@ export type TestimonialSectionsProps = {
 export const TestimonialSections = ({ testimonials }: TestimonialSectionsProps) => {
   return (
     <section className="container">
-      <div className="mb-16 flex flex-col items-center justify-center gap-3">
+      <div className="mx-8 mb-16 flex flex-col items-center justify-center gap-3 text-center">
         <h6 className="text-xl font-semibold text-indigo-700">Testimonials</h6>
-        <h1 className="text-5xl font-semibold">Countless users, countless smiles</h1>
+        <h1 className="text-3xl font-semibold md:text-5xl">Countless users, countless smiles</h1>
         <h6 className="text-xl font-normal text-neutral-600">
           Explore our community's journey and discover why satisfaction defines us.
         </h6>
@@ -19,7 +19,7 @@ export const TestimonialSections = ({ testimonials }: TestimonialSectionsProps) 
           return (
             <div
               key={`${testimonial.username}-${idx}`}
-              className="w-[384px] break-inside-avoid-column"
+              className="max-w-[340px] break-inside-avoid-column"
             >
               <TestimonialCard {...testimonial} />
             </div>

--- a/apps/marketing/src/pages/showcases/testimonial-section.tsx
+++ b/apps/marketing/src/pages/showcases/testimonial-section.tsx
@@ -82,7 +82,7 @@ const testimonials: TestimonialSectionsProps["testimonials"] = [
 export const TestimonialSectionsShowcase = () => {
   return (
     <section className={"flex h-full flex-col items-center bg-white"}>
-      <div className="mx-auto items-center overflow-x-auto p-24 align-top">
+      <div className="mx-auto items-center overflow-auto px-4 pt-14 align-top md:px-4 lg:px-24">
         <TestimonialSections testimonials={testimonials} />
       </div>
     </section>


### PR DESCRIPTION
### Issue / Problems:

| Submitted | Design (expected) | Remarks |
| --- | --- | --- |
| <img height="531" alt="Screenshot 2025-09-11 at 12 24 57 AM" src="https://github.com/user-attachments/assets/dc2c7939-aa75-4b34-83b9-cc6ab2c3d430" />   | <img height="500" alt="Screenshot 2025-09-11 at 12 25 42 AM" src="https://github.com/user-attachments/assets/1711762e-d985-4f44-ba3a-ab6563989477" /> | Text is not centered. Cards container's horizontal padding too big |
| <img height="511" alt="image" src="https://github.com/user-attachments/assets/da18bfe4-2c95-4349-b2d5-1ef68ccc75b1" /> |  <img height="519" alt="Screenshot 2025-09-11 at 12 27 21 AM" src="https://github.com/user-attachments/assets/64af2e15-f1c3-48e5-bac0-b8027d356766" /> | Text header misaligned. Card element too big and overflown. |
