### PR TITLE
fix(marketing): fix duplicated React element keys across pages and remove #root div overflow-hidden

### DIFF
--- a/apps/marketing/src/components/layout/navbar.tsx
+++ b/apps/marketing/src/components/layout/navbar.tsx
@@ -58,9 +58,9 @@ const MobileNav = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }
         </button>
       </div>
       <div className="flex flex-1 flex-col gap-2">
-        {navigationLinks.map((link) => (
+        {navigationLinks.map((link, idx) => (
           <a
-            key={link.href}
+            key={`link-${idx}-${link.href}`}
             href={link.href}
             className="rounded px-3 py-2 text-sm font-normal text-neutral-900 focus:outline-none focus:ring-4 focus:ring-indigo-500/20"
           >
@@ -92,9 +92,9 @@ export const Navbar = () => {
           {/* Desktop Navigation */}
           <div className="hidden flex-1 items-center justify-between gap-24 xl:flex">
             <div className="flex gap-8">
-              {navigationLinks.map((link) => (
+              {navigationLinks.map((link, idx) => (
                 <a
-                  key={link.href}
+                  key={`link-${idx}-${link.href}`}
                   href={link.href}
                   className={cn(
                     "rounded px-0.5 py-1 font-medium text-neutral-600",

--- a/apps/marketing/src/components/ui/profile-card.tsx
+++ b/apps/marketing/src/components/ui/profile-card.tsx
@@ -60,7 +60,7 @@ export const ProfileCard = ({
           {socialLogos.map((item, idx) => {
             return (
               <img
-                key={`${item.label}-${idx}`}
+                key={`profile-${item.label}-${idx}`}
                 className="h-5 w-5 items-center justify-center"
                 src={item.logoImg}
                 alt={item.label}

--- a/apps/marketing/src/index.css
+++ b/apps/marketing/src/index.css
@@ -12,6 +12,5 @@
     margin: 0;
     padding: 0;
     height: 100vh;
-    overflow: hidden;
   }
 }

--- a/apps/marketing/src/pages/landing/sections/testimonial-section.tsx
+++ b/apps/marketing/src/pages/landing/sections/testimonial-section.tsx
@@ -18,7 +18,7 @@ export const TestimonialSections = ({ testimonials }: TestimonialSectionsProps) 
         {testimonials.map((testimonial, idx) => {
           return (
             <div
-              key={`${testimonial.username}-${idx}`}
+              key={`testimonial-card-${testimonial.username}-${idx}`}
               className="max-w-[384px] break-inside-avoid-column"
             >
               <TestimonialCard {...testimonial} />


### PR DESCRIPTION
We saw error in console log:

```shell
Encountered two children with the same key, `#`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.
overrideMethod @ hook.js:608Understand this error
```

We fix it in different places where we use `<... key={..} />`