### PR TITLE
fix(marketing): fixing wrong section content for features-side-image-section 

### DIFF
--- a/apps/marketing/src/App.tsx
+++ b/apps/marketing/src/App.tsx
@@ -4,7 +4,7 @@ import { LandingPage } from "~/pages/landing/page";
 
 import { BlogCardShowCase } from "~/pages/showcase/blog-card";
 import { HeroFeatureSectionShowcase } from "~/pages/showcase/hero-feature-section";
-import { HeroSectionShowcase } from "./pages/showcase/hero-simple-section";
+import { HeroSectionShowcase } from "~/pages/showcase/hero-simple-section";
 import { NavbarShowcase } from "~/pages/showcase/navbar";
 import { TestimonialCardShowcase } from "~/pages/showcase/testimonial-card";
 import { TestimonialSectionsShowcase } from "~/pages/showcase/testimonial-section";
@@ -13,7 +13,7 @@ import {
   FeaturesColorSectionShowcase,
   FeaturesGlassSectionShowcase,
 } from "~/pages/showcase/features-side-image-section";
-import { FeaturesGridSectionShowcase } from "./pages/showcase/features-grid-section";
+import { FeaturesGridSectionShowcase } from "~/pages/showcase/features-grid-section";
 
 function App() {
   return (
@@ -27,7 +27,7 @@ function App() {
             <Route index element={<FeaturesColorSectionShowcase />} />
             <Route path="right" element={<FeaturesGlassSectionShowcase />} />
           </Route>
-          <Route path="feature-grid-section" element={<FeaturesGridSectionShowcase />} />
+          <Route path="features-grid-section" element={<FeaturesGridSectionShowcase />} />
           <Route path="navbar" element={<NavbarShowcase />} />
           <Route path="testimonial-card" element={<TestimonialCardShowcase />} />
           <Route path="hero-section" element={<HeroSectionShowcase />} />

--- a/apps/marketing/src/pages/landing/sections/features-side-image-section.tsx
+++ b/apps/marketing/src/pages/landing/sections/features-side-image-section.tsx
@@ -35,8 +35,8 @@ const FeaturesSideImageBaseSection = ({
   features,
 }: FeaturesSideImageSectionProps) => {
   return (
-    <div className="w-full self-stretch bg-white px-3 py-12 lg:p-24">
-      <div className="container mx-auto flex max-w-[1440px] flex-col items-center justify-center gap-12 self-stretch rounded-lg lg:gap-16">
+    <div className="w-full self-stretch bg-white px-3 py-12 md:px-4 md:py-16 lg:p-24">
+      <div className="flex flex-col items-center justify-center gap-12 self-stretch rounded-lg lg:gap-16">
         <div className="header flex flex-col gap-5 self-stretch lg:px-40">
           <div className="flex flex-col justify-center gap-3 self-stretch lg:px-10">
             <span className="text-center text-base font-semibold text-indigo-700">

--- a/apps/marketing/src/pages/showcase/features-side-image-section.tsx
+++ b/apps/marketing/src/pages/showcase/features-side-image-section.tsx
@@ -5,16 +5,16 @@ import {
 
 export const FeaturesGlassSectionShowcase = () => {
   return (
-    <section>
-      <FeaturesSideColorImageSection />
+    <section className="lg:max-[1440px] mx-auto p-4">
+      <FeaturesSideGlassImageSection />
     </section>
   );
 };
 
 export const FeaturesColorSectionShowcase = () => {
   return (
-    <section>
-      <FeaturesSideGlassImageSection />
+    <section className="lg:max-[1440px] mx-auto p-4">
+      <FeaturesSideColorImageSection />
     </section>
   );
 };


### PR DESCRIPTION
We put them wrongly. We should swap the content of `FeaturesSideGlassImageSection` and `FeaturesSideColorImageSection`.