### PR TITLE
chore(marketing): UI layout fix for showcases page to improve GFE challenges accuracy

### DIFF
--- a/apps/marketing/src/features/forum/components/profile-card/profile-card.stories.tsx
+++ b/apps/marketing/src/features/forum/components/profile-card/profile-card.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
   decorators: [
     // Showcase layout to get >= 90% similarity score in Greatfrontend challenge submission.
     (Story) => (
-      <section className="flex h-screen flex-col items-center bg-gray-200">
+      <section className="flex h-screen flex-col items-center bg-gray-200 p-4">
         <div className="mx-auto flex items-center overflow-x-auto py-[200px] align-top">
           <Story />
         </div>

--- a/apps/marketing/src/features/marketing/components/features-grid-section/feature-grid-section.stories.tsx
+++ b/apps/marketing/src/features/marketing/components/features-grid-section/feature-grid-section.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <section className="flex min-h-screen w-full flex-col bg-gray-500 p-4">
+      <section className="flex min-h-screen w-full flex-col bg-gray-50 p-4">
         <div className="align-top">
           <Story />
         </div>

--- a/apps/marketing/src/features/marketing/components/features-side-img-section/features-side-img-section.stories.tsx
+++ b/apps/marketing/src/features/marketing/components/features-side-img-section/features-side-img-section.stories.tsx
@@ -13,7 +13,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <section className="flex h-full min-h-screen flex-col bg-gray-500 p-4">
+      <section className="flex h-full min-h-screen flex-col bg-gray-50 p-4">
         <div className="align-top">
           <Story />
         </div>

--- a/apps/marketing/src/features/marketing/components/hero-feature-section/hero-feature-section.stories.tsx
+++ b/apps/marketing/src/features/marketing/components/hero-feature-section/hero-feature-section.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <section className="flex h-full min-h-screen flex-col bg-gray-500 p-4">
+      <section className="flex h-full min-h-screen flex-col bg-gray-50 p-4">
         <div className="mx-auto align-top">
           <Story />
         </div>

--- a/apps/marketing/src/features/marketing/components/hero-simple-section/hero-simple-section.stories.tsx
+++ b/apps/marketing/src/features/marketing/components/hero-simple-section/hero-simple-section.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <section className="flex h-full min-h-screen flex-col bg-gray-500 p-4">
+      <section className="flex h-full min-h-screen flex-col bg-gray-50 p-4">
         <div className="align-top">
           <Story />
         </div>


### PR DESCRIPTION
All fixes here for poor or low quality accuracy in GFE challenges:

1. [Feature Side Image Section](https://www.greatfrontend.com/projects/s/features-side-image-section-simple-react-vite-tailwind-typescript-5119ae6f)
    - Showcase body padding (p-4)
 
2. [Hero Feature Section] (https://www.greatfrontend.com/projects/s/hero-feature-section-feature-simple-react-vite-tailwind-typescript-c4cc4d4a)
    - Showcase body padding (p-4)
    - Mobile title font weight too light (semibold)

3. [Hero Simple Section](https://www.greatfrontend.com/projects/s/hero-section-simple-react-vite-tailwind-typescript-37cf44f2)
    - Outer margin top / padding top is too big (everything is too low)
    - Title (desktop) width too narrow causing more lines
    - Title (ipad) font size is too small
    - Title (mobile) width too large and missing padding x
    - Outer layout (mobile) missing padding x
    - Buttons too small

