### PR TITLE
fix(packages-ui): put use client directive for nextjs import

### DIFF
--- a/packages/ui/src/button.tsx
+++ b/packages/ui/src/button.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+"use client";
 
 export interface ButtonProps {
   label?: string;


### PR DESCRIPTION
### Issue / Error:

Found this when building the docs app. It seems like the imported packages/ui/button does not have nextjs Client component directive.
```
$ cd apps/docs && pnpm build

> docs@0.1.0 build /project/workspace/apps/docs
> next build

   ▲ Next.js 15.5.0

   Creating an optimized production build ...
 ✓ Compiled successfully in 5.9s
 ✓ Linting and checking validity of types    
 ✓ Collecting page data    
Error occurred prerendering page "/". Read more: https://nextjs.org/docs/messages/prerender-error
Error: Event handlers cannot be passed to Client Component props.
  {className: ..., onClick: function onClick, children: ...}
                            ^^^^^^^^^^^^^^^^
If you need interactivity, consider converting part of this to a Client Component.
    at stringify (<anonymous>) {
  digest: '1401213011'
}
Export encountered an error on /page: /, exiting the build.
 ⨯ Next.js build worker exited with code: 1 and signal: null
 ELIFECYCLE  Command failed with exit code 1.
```

### Fix implementation

Simply adding back the directive in `packages/ui/button.tsx` works. 
```
"use client"; 
...
```
